### PR TITLE
Improve event store api

### DIFF
--- a/lib/sandthorn_driver_sequel/event_store.rb
+++ b/lib/sandthorn_driver_sequel/event_store.rb
@@ -63,6 +63,12 @@ module SandthornDriverSequel
       end
     end
 
+    def all aggregate_type
+      return get_aggregate_ids(aggregate_type: aggregate_type).map do |id|
+        get_aggregate_events_from_snapshot(id)
+      end
+    end
+
     def build_snapshot_event(snapshot)
       {
         aggregate: snapshot.data,
@@ -74,6 +80,8 @@ module SandthornDriverSequel
       get_aggregate_events_from_snapshot(aggregate_id)
     end
 
+    
+
     def get_aggregate_ids(aggregate_type: nil)
       driver.execute do |db|
         access = get_aggregate_access(db)
@@ -83,7 +91,7 @@ module SandthornDriverSequel
 
     def get_aggregate_list_by_typename(type)
       warn(":get_aggregate_list_by_typenames is deprecated. Use :get_aggregate_ids")
-      get_aggregate_ids(type: type)
+      get_aggregate_ids(aggregate_type: type)
     end
 
     def get_all_types

--- a/spec/driver_interface_spec.rb
+++ b/spec/driver_interface_spec.rb
@@ -17,7 +17,8 @@ module SandthornDriverSequel
         :get_events,
         :context,
         :driver,
-        :all
+        :all,
+        :find
       ]
 
       methods.each do |method|

--- a/spec/driver_interface_spec.rb
+++ b/spec/driver_interface_spec.rb
@@ -16,7 +16,8 @@ module SandthornDriverSequel
         :get_snapshot,
         :get_events,
         :context,
-        :driver
+        :driver,
+        :all
       ]
 
       methods.each do |method|

--- a/spec/event_store_spec.rb
+++ b/spec/event_store_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+module SandthornDriverSequel
+  describe EventStore do
+    
+    before(:each) { prepare_for_test context: nil; }
+    let(:event_store) { SandthornDriverSequel.driver_from_url url: event_store_url }  
+    
+    describe("when getting the same data from find and get_aggregate_events_from_snapshot") do
+      let(:test_events) do
+        e = [] 
+        e << {aggregate_version: 1, event_name: "new",  event_args: {:method_name=>"new", :method_args=>[], :attribute_deltas=>[{:attribute_name=>"aggregate_id", :old_value=>nil, :new_value=>aggregate_id}]}}
+        e << {aggregate_version: 2, event_name: "foo",  event_args: "noop"}
+        e << {aggregate_version: 3, event_name: "flubber",  event_args: "noop"}
+      end
+      let(:aggregate_id) {"c0456e26-e29a-4f67-92fa-130b3a31a39b"}
+      
+      
+
+      before do
+        event_store.save_events test_events, aggregate_id, String
+      end
+
+      context "find" do
+
+        let(:find_events) do
+          event_store.find aggregate_id
+        end
+
+        let(:get_aggregate_events_from_snapshot_events) do
+          event_store.get_aggregate_events_from_snapshot aggregate_id
+        end
+
+        it "should get same events" do
+          find_events.each_with_index do |event, index|
+            expect(find_events[index]).to eql get_aggregate_events_from_snapshot_events[index]
+          end
+        end
+      end
+
+      context "all" do
+
+        let(:test_events_2) do
+          e = [] 
+          e << {aggregate_version: 1, event_name: "new",  event_args: {:method_name=>"new", :method_args=>[], :attribute_deltas=>[{:attribute_name=>"aggregate_id", :old_value=>nil, :new_value=>aggregate_id_2}]}}
+          e << {aggregate_version: 2, event_name: "foo",  event_args: "noop"}
+          e << {aggregate_version: 3, event_name: "flubber",  event_args: "noop"}
+        end
+        let(:aggregate_id_2) {"d0456e26-e29a-4f67-92fa-130b3a31a39b"}
+
+        before do
+          event_store.save_events test_events_2, aggregate_id_2, String
+        end
+
+        let(:all_events) do
+          event_store.all String
+        end
+
+        let(:obsolete_all) do
+          return event_store.get_aggregate_ids(aggregate_type: String).map do |id|
+            event_store.get_aggregate_events_from_snapshot(id)
+          end
+        end
+
+        it "should get two arrays of events" do
+          expect(all_events.length).to eql 2
+        end
+
+        it "should get same events" do
+          all_events.each_with_index do |events, index|
+            expect(events).to eql obsolete_all[index]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added `.all` and `.find` to make the interface between Sandthorn and its driver more generic.
